### PR TITLE
Potential fix for code scanning alert no. 40: Log Injection

### DIFF
--- a/app/routers/api_deploy.py
+++ b/app/routers/api_deploy.py
@@ -385,7 +385,8 @@ async def deploy_custom_modes(request: DeployRequest):
                                 errors.append(error_msg)
                                 logger.error(error_msg)
                         else:
-                            error_msg = f"Command file not found: {command_path}"
+                            sanitized_command_path = command_path.replace('\r', '').replace('\n', '')
+                            error_msg = f"Command file not found: {sanitized_command_path}"
                             errors.append(error_msg)
                             logger.warning(error_msg)
 


### PR DESCRIPTION
Potential fix for [https://github.com/lazygophers/roo/security/code-scanning/40](https://github.com/lazygophers/roo/security/code-scanning/40)

To resolve this log injection vulnerability, sanitize any user input that could end up in log entries. Specifically, prior to logging `error_msg` (which interpolates `command_path`), remove all newline and carriage return characters from `command_path`. The safest, least invasive fix is to sanitize `command_path` when constructing `error_msg` before it is added to `errors` or sent to the logger. 

**Best approach:**  
- Before logging or constructing messages containing `command_path` (or any user input), replace all `\r` and `\n` characters in it with the empty string.
- This should be done on/around line 388 before adding to `error_msg`.

**Precise edit:**  
- Update the block beginning at line 388 so that when `error_msg` is constructed, the potentially malicious characters are sanitized.
- Change all log/error append/constructs involving `command_path` to sanitize it, but do **not** otherwise alter functionality.

**What is needed:**  
- No new dependencies are required; just use the Python built-in `str.replace()` functionality.
- If needed elsewhere, consider creating a simple helper function for sanitization, but here, the direct in-place sanitize is sufficient given the code shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
