### PR TITLE
refactor(cache): 移除缓存工具中所有Redis引用

### DIFF
--- a/app/routers/api_file_security.py
+++ b/app/routers/api_file_security.py
@@ -325,7 +325,7 @@ async def get_security_summary():
 
 class FileValidationRequest(BaseModel):
     """文件操作验证请求模型"""
-    operation: str = Field(..., regex=r"^(read|write|delete|list)$", description="操作类型")
+    operation: str = Field(..., pattern=r"^(read|write|delete|list)$", description="操作类型")
     file_path: str = Field(..., min_length=1, max_length=1000, description="文件路径")
     check_size: bool = Field(default=True, description="是否检查文件大小")
 

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -3,11 +3,12 @@ MCP (Model Context Protocol) API 路由
 提供 SSE 和 Streamable HTTP 端点
 """
 
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, Request, Response, HTTPException
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field, validator
 import json
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from app.core.logging import setup_logging
 from app.core.secure_logging import sanitize_for_log
@@ -17,6 +18,44 @@ from app.core.mcp_server import get_mcp_server
 logger = setup_logging()
 
 router = APIRouter(prefix="/mcp", tags=["MCP"])
+
+# Pydantic 模型定义用于输入验证
+class MCPToolCallRequest(BaseModel):
+    """MCP 工具调用请求模型"""
+    name: str = Field(..., min_length=1, max_length=100, description="工具名称")
+    arguments: Dict[str, Any] = Field(default_factory=dict, description="工具参数")
+
+    @validator('name')
+    def validate_tool_name(cls, v):
+        # 只允许字母数字、下划线和连字符
+        import re
+        if not re.match(r'^[a-zA-Z0-9_-]+$', v):
+            raise ValueError('工具名称只能包含字母、数字、下划线和连字符')
+        return v
+
+    @validator('arguments')
+    def validate_arguments(cls, v):
+        # 限制参数字典的大小以防止DoS攻击
+        if len(str(v)) > 10000:  # 限制序列化后的大小
+            raise ValueError('工具参数过大，序列化后不能超过10000字符')
+
+        # 检查参数数量
+        if isinstance(v, dict) and len(v) > 50:
+            raise ValueError('工具参数数量不能超过50个')
+
+        # 检查嵌套深度
+        def check_depth(obj, depth=0):
+            if depth > 10:  # 限制嵌套深度
+                raise ValueError('工具参数嵌套深度不能超过10层')
+            if isinstance(obj, dict):
+                for value in obj.values():
+                    check_depth(value, depth + 1)
+            elif isinstance(obj, list):
+                for item in obj:
+                    check_depth(item, depth + 1)
+
+        check_depth(v)
+        return v
 
 @router.get("/tools")
 async def list_mcp_tools():
@@ -43,17 +82,13 @@ async def list_mcp_tools():
         }
 
 @router.post("/call-tool")
-async def call_mcp_tool(request: Dict[str, Any]):
+async def call_mcp_tool(request: MCPToolCallRequest):
     """调用 MCP 工具"""
     try:
-        tool_name = request.get("name")
-        arguments = request.get("arguments", {})
-        
-        if not tool_name:
-            return {
-                "success": False,
-                "message": "Tool name is required"
-            }
+        tool_name = request.name
+        arguments = request.arguments
+
+        # 输入验证已通过 Pydantic 模型完成
         
         # 获取MCP服务器实例并调用工具
         try:
@@ -273,15 +308,23 @@ async def list_mcp_categories():
 async def list_tools_by_category(category: str):
     """按分类列出 MCP 工具"""
     try:
+        # 输入验证：只允许安全的分类名称
+        import re
+        if not re.match(r'^[a-zA-Z0-9_-]+$', category) or len(category) > 50:
+            raise HTTPException(
+                status_code=400,
+                detail="无效的分类名称：只能包含字母、数字、下划线和连字符，长度不超过50字符"
+            )
+
         tools_service = get_mcp_tools_service()
-        
+
         # 验证分类是否存在
         category_info = tools_service.get_category(category)
         if not category_info:
-            return {
-                "success": False,
-                "message": f"Category '{sanitize_for_log(category)}' not found"
-            }
+            raise HTTPException(
+                status_code=404,
+                detail=f"分类 '{sanitize_for_log(category)}' 未找到"
+            )
         
         tools = tools_service.get_tools(category=category, enabled_only=True)
         

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -5,7 +5,7 @@ MCP (Model Context Protocol) API 路由
 
 from fastapi import APIRouter, Request, Response, HTTPException
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 import json
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -25,7 +25,8 @@ class MCPToolCallRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=100, description="工具名称")
     arguments: Dict[str, Any] = Field(default_factory=dict, description="工具参数")
 
-    @validator('name')
+    @field_validator('name')
+    @classmethod
     def validate_tool_name(cls, v):
         # 只允许字母数字、下划线和连字符
         import re
@@ -33,7 +34,8 @@ class MCPToolCallRequest(BaseModel):
             raise ValueError('工具名称只能包含字母、数字、下划线和连字符')
         return v
 
-    @validator('arguments')
+    @field_validator('arguments')
+    @classmethod
     def validate_arguments(cls, v):
         # 限制参数字典的大小以防止DoS攻击
         if len(str(v)) > 10000:  # 限制序列化后的大小

--- a/frontend/src/components/CacheTools/CacheToolsConfigModal.tsx
+++ b/frontend/src/components/CacheTools/CacheToolsConfigModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, {useState} from 'react';
-import {Alert, Space, Tooltip, Typography, Divider} from 'antd';
+import {Alert, Space, Tooltip, Typography} from 'antd';
 import {ModalForm, ProCard, ProFormDigit, ProFormSelect, ProFormSwitch, ProFormText} from '@ant-design/pro-components';
 import {ClockCircleOutlined, DatabaseOutlined, InfoCircleOutlined, SettingOutlined} from '@ant-design/icons';
 import {apiClient} from '../../api';
@@ -21,10 +21,6 @@ export interface CacheToolsConfig {
     compression_enabled: boolean;
     stats_enabled: boolean;
     // Backend-specific configs
-    redis_host?: string;
-    redis_port?: number;
-    redis_db?: number;
-    redis_password?: string;
     diskcache_directory?: string;
     diskcache_size_limit?: number;
     memcached_host?: string;
@@ -81,12 +77,7 @@ const CacheToolsConfigModal: React.FC<CacheToolsConfigModalProps> = ({
             // 提取后端配置
             const backendConfig: any = {};
 
-            if (values.backend_type === 'redis') {
-                if (values.redis_host) backendConfig.host = values.redis_host;
-                if (values.redis_port) backendConfig.port = values.redis_port;
-                if (values.redis_db !== undefined) backendConfig.db = values.redis_db;
-                if (values.redis_password) backendConfig.password = values.redis_password;
-            } else if (values.backend_type === 'diskcache') {
+            if (values.backend_type === 'diskcache') {
                 if (values.diskcache_directory) backendConfig.directory = values.diskcache_directory;
                 if (values.diskcache_size_limit) backendConfig.size_limit = values.diskcache_size_limit * 1024 * 1024; // Convert MB to bytes
             } else if (values.backend_type === 'memcached') {
@@ -132,7 +123,6 @@ const CacheToolsConfigModal: React.FC<CacheToolsConfigModalProps> = ({
     // 存储后端选项
     const backendOptions = [
         {label: 'TinyDB（默认）', value: 'tinydb', description: '基于文件的轻量级数据库'},
-        {label: 'Redis', value: 'redis', description: '高性能内存数据库'},
         {label: 'DiskCache', value: 'diskcache', description: '磁盘缓存，支持大容量存储'},
         {label: 'Memcached', value: 'memcached', description: '分布式内存缓存系统'},
         {label: 'LMDB', value: 'lmdb', description: '高性能嵌入式数据库'}
@@ -170,7 +160,7 @@ const CacheToolsConfigModal: React.FC<CacheToolsConfigModalProps> = ({
         >
             <Alert
                 message="缓存工具配置"
-                description="配置Redis风格缓存工具的运行参数，包括默认TTL时间、内存限制和持久化选项。"
+                description="配置缓存工具的运行参数，包括默认TTL时间、内存限制和持久化选项。"
                 type="info"
                 showIcon={false}
                 style={{marginBottom: 24}}
@@ -209,49 +199,9 @@ const CacheToolsConfigModal: React.FC<CacheToolsConfigModalProps> = ({
                 rules={[
                     {required: true, message: '请选择存储后端'}
                 ]}
-                extra="TinyDB为默认选项，无需额外服务；Redis、Memcached需要独立运行的服务"
+                extra="TinyDB为默认选项，无需额外服务；Memcached需要独立运行的服务"
                 initialValue={'tinydb'}
             />
-
-            {/* Redis配置 */}
-            {currentBackend === 'redis' && (
-                <>
-                    <ProFormText
-                        name="redis_host"
-                        label="Redis主机地址"
-                        placeholder="localhost"
-                        initialValue="localhost"
-                        extra="Redis服务器的主机地址"
-                    />
-                    <ProFormDigit
-                        name="redis_port"
-                        label="Redis端口"
-                        placeholder="6379"
-                        initialValue={6379}
-                        min={1}
-                        max={65535}
-                        extra="Redis服务器的端口号"
-                    />
-                    <ProFormDigit
-                        name="redis_db"
-                        label="数据库索引"
-                        placeholder="0"
-                        initialValue={0}
-                        min={0}
-                        max={15}
-                        extra="Redis数据库索引（0-15）"
-                    />
-                    <ProFormText
-                        name="redis_password"
-                        label="密码"
-                        placeholder="可选"
-                        fieldProps={{
-                            type: 'password'
-                        }}
-                        extra="Redis连接密码（可选）"
-                    />
-                </>
-            )}
 
             {/* DiskCache配置 */}
             {currentBackend === 'diskcache' && (
@@ -428,15 +378,15 @@ const CacheToolsConfigModal: React.FC<CacheToolsConfigModalProps> = ({
                 />
             )}
 
-            {/* Redis/Memcached 特有选项提示 */}
-            {(currentBackend === 'redis' || currentBackend === 'memcached') && (
+            {/* Memcached 特有选项提示 */}
+            {currentBackend === 'memcached' && (
                 <Alert
-                    message={`${currentBackend === 'redis' ? 'Redis' : 'Memcached'} 存储特性`}
+                    message="Memcached 存储特性"
                     description={
                         <div>
                             <p><strong>内存存储</strong>：数据存储在内存中，重启后数据会丢失</p>
                             <p><strong>高性能</strong>：提供极高的读写性能</p>
-                            <p><strong>分布式</strong>：{currentBackend === 'redis' ? '支持集群和主从复制' : '原生支持分布式部署'}</p>
+                            <p><strong>分布式</strong>：原生支持分布式部署</p>
                         </div>
                     }
                     type="info"

--- a/frontend/src/components/CacheTools/CacheToolsConfigModal.tsx
+++ b/frontend/src/components/CacheTools/CacheToolsConfigModal.tsx
@@ -172,8 +172,7 @@ const CacheToolsConfigModal: React.FC<CacheToolsConfigModalProps> = ({
                 message="缓存工具配置"
                 description="配置Redis风格缓存工具的运行参数，包括默认TTL时间、内存限制和持久化选项。"
                 type="info"
-                icon={<InfoCircleOutlined/>}
-                showIcon
+                showIcon={false}
                 style={{marginBottom: 24}}
             />
 

--- a/frontend/src/components/CacheTools/CacheToolsConfigModal.tsx
+++ b/frontend/src/components/CacheTools/CacheToolsConfigModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, {useState} from 'react';
-import {Alert, Space, Tooltip, Typography} from 'antd';
+import {Alert, Space, Tooltip, Typography, Divider} from 'antd';
 import {ModalForm, ProCard, ProFormDigit, ProFormSelect, ProFormSwitch, ProFormText} from '@ant-design/pro-components';
 import {ClockCircleOutlined, DatabaseOutlined, InfoCircleOutlined, SettingOutlined} from '@ant-design/icons';
 import {apiClient} from '../../api';

--- a/frontend/src/components/FileTools/FileSecurityStatus.tsx
+++ b/frontend/src/components/FileTools/FileSecurityStatus.tsx
@@ -165,7 +165,6 @@ const FileSecurityStatus: React.FC<FileSecurityStatusProps> = ({
             <Button 
               size="small" 
               type="primary" 
-              icon={<SettingOutlined />}
               onClick={() => navigate('/file-security')}
             >
               配置
@@ -188,12 +187,10 @@ const FileSecurityStatus: React.FC<FileSecurityStatusProps> = ({
       extra={
         <Space>
           <Button 
-            icon={<ReloadOutlined />} 
             onClick={loadSecurityInfo}
             size="small"
           />
           <Button 
-            icon={<SettingOutlined />} 
             type="primary"
             onClick={() => navigate('/file-security')}
             size="small"

--- a/frontend/src/components/FileTools/FileToolsConfigModal.tsx
+++ b/frontend/src/components/FileTools/FileToolsConfigModal.tsx
@@ -305,7 +305,7 @@ const FileToolsConfigModal: React.FC<FileToolsConfigModalProps> = ({
                     title={<span style={{ color: currentTheme.token?.colorText }}>📖 可读取目录</span>}
                     size="small" 
                     extra={
-                      <Button type="text" size="small" icon={<EditOutlined />} 
+                      <Button type="text" size="small"  
                         onClick={() => handleEditPaths('readable')}>编辑</Button>
                     }
                     style={{
@@ -334,7 +334,7 @@ const FileToolsConfigModal: React.FC<FileToolsConfigModalProps> = ({
                     title={<span style={{ color: currentTheme.token?.colorText }}>✏️ 可写入目录</span>}
                     size="small" 
                     extra={
-                      <Button type="text" size="small" icon={<EditOutlined />} 
+                      <Button type="text" size="small"  
                         onClick={() => handleEditPaths('writable')}>编辑</Button>
                     }
                     style={{
@@ -366,7 +366,7 @@ const FileToolsConfigModal: React.FC<FileToolsConfigModalProps> = ({
                     title={<span style={{ color: currentTheme.token?.colorText }}>🗑️ 可删除目录</span>}
                     size="small" 
                     extra={
-                      <Button type="text" size="small" icon={<EditOutlined />} 
+                      <Button type="text" size="small"  
                         onClick={() => handleEditPaths('deletable')}>编辑</Button>
                     }
                     style={{
@@ -395,7 +395,7 @@ const FileToolsConfigModal: React.FC<FileToolsConfigModalProps> = ({
                     title={<span style={{ color: currentTheme.token?.colorText }}>🚫 禁止访问目录</span>}
                     size="small" 
                     extra={
-                      <Button type="text" size="small" icon={<EditOutlined />} 
+                      <Button type="text" size="small"  
                         onClick={() => handleEditPaths('forbidden')}>编辑</Button>
                     }
                     style={{
@@ -516,7 +516,6 @@ const FileToolsConfigModal: React.FC<FileToolsConfigModalProps> = ({
                           保存限制配置
                         </Button>
                         <Button onClick={reloadConfig} loading={loading}>
-                          <ReloadOutlined />
                           重新加载
                         </Button>
                       </Space>
@@ -567,7 +566,7 @@ const FileToolsConfigModal: React.FC<FileToolsConfigModalProps> = ({
 
       <div style={{ textAlign: 'right', paddingTop: 16, borderTop: '1px solid #f0f0f0' }}>
         <Space>
-          <Button icon={<ReloadOutlined />} onClick={reloadConfig} loading={loading}>
+          <Button onClick={reloadConfig} loading={loading}>
             重新加载配置
           </Button>
           <Button onClick={onCancel}>关闭</Button>

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Layout, Button, Space, Menu, theme } from 'antd';
+
+const { Sider, Header, Content } = Layout;
 import { HomeOutlined, SettingOutlined, GithubOutlined, ApiOutlined } from '@ant-design/icons';
 import { useNavigate, useLocation } from 'react-router-dom';
 import ThemeToggle from '../Theme/ThemeToggle';

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { Layout, Button, Space, Menu, theme } from 'antd';
-
-const { Sider, Header, Content } = Layout;
 import { HomeOutlined, SettingOutlined, GithubOutlined, ApiOutlined } from '@ant-design/icons';
 import { useNavigate, useLocation } from 'react-router-dom';
 import ThemeToggle from '../Theme/ThemeToggle';
@@ -9,12 +7,11 @@ import SystemMonitorMenuItem from '../SystemMonitor/SystemMonitorMenuItem';
 import LicenseInfo from '../License/LicenseInfo';
 import './AppLayout.css';
 
+const { Sider, Header, Content } = Layout;
 
 interface AppLayoutProps {
   children: React.ReactNode;
 }
-
-const { Header, Content, Sider } = Layout;
 
 const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const {

--- a/frontend/src/pages/MCPToolsManagement.tsx
+++ b/frontend/src/pages/MCPToolsManagement.tsx
@@ -28,8 +28,7 @@ import {
     ExclamationCircleOutlined,
     FilterOutlined,
     InfoCircleOutlined,
-    ReloadOutlined,
-    SettingOutlined
+    ReloadOutlined
 } from '@ant-design/icons';
 import {apiClient, MCPCategoryInfo, MCPStatusResponse, MCPToolInfo} from '../api';
 import {useTheme} from '../contexts/ThemeContext';
@@ -216,7 +215,7 @@ const MCPToolsManagement: React.FC = () => {
                     {
                         id: 'cache',
                         name: '缓存工具',
-                        description: 'Redis风格的缓存操作相关工具',
+                        description: '缓存操作相关工具',
                         icon: '🗄️',
                         enabled: true
                     }
@@ -404,19 +403,6 @@ const MCPToolsManagement: React.FC = () => {
                     title={
                         <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
                             <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
-                                <div style={{
-                                    width: 32,
-                                    height: 32,
-                                    borderRadius: '50%',
-                                    backgroundColor: enabledBg,
-                                    border: `2px solid ${enabledBorder}`,
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    fontSize: '14px'
-                                }}>
-                                    {categoryInfo?.icon || '🔧'}
-                                </div>
                                 <Text strong style={{fontSize: 14, color: token?.colorText}}>{tool.name}</Text>
                             </div>
                             <Tag color={tool.implementation_type === 'builtin' ? 'blue' : 'green'}>
@@ -547,21 +533,19 @@ const MCPToolsManagement: React.FC = () => {
                                         width: '100%'
                                     }}>
                                         <Space>
-                                            <span style={{
-                                                fontSize: '18px',
-                                                opacity: category.enabled ? 1 : 0.5
-                                            }}>{category.icon}</span>
                                             <Title level={4} style={{margin: 0, opacity: category.enabled ? 1 : 0.5}}>
                                                 {category.name}
                                             </Title>
                                             <Text type="secondary">({enabledCount}/{categoryTools.length})</Text>
-                                            <Switch
-                                                size="small"
-                                                checked={category.enabled}
-                                                onChange={(checked) => toggleCategory(category, checked)}
-                                                checkedChildren="启用"
-                                                unCheckedChildren="禁用"
-                                            />
+                                            <div onClick={(e) => e.stopPropagation()}>
+                                                <Switch
+                                                    size="small"
+                                                    checked={category.enabled}
+                                                    onChange={(checked) => toggleCategory(category, checked)}
+                                                    checkedChildren="启用"
+                                                    unCheckedChildren="禁用"
+                                                />
+                                            </div>
                                             {category.enabled && (
                                                 <Tag
                                                     color={enabledCount === categoryTools.length ? 'success' : enabledCount > 0 ? 'warning' : 'default'}>
@@ -575,7 +559,10 @@ const MCPToolsManagement: React.FC = () => {
                                                     <Button
                                                         type="text"
                                                         size="small"
-                                                        onClick={() => setFileToolsConfigModal(true)}
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            setFileToolsConfigModal(true);
+                                                        }}
                                                         style={{
                                                             color: currentTheme.token?.colorPrimary,
                                                             borderColor: currentTheme.token?.colorPrimary,
@@ -602,7 +589,10 @@ const MCPToolsManagement: React.FC = () => {
                                                     <Button
                                                         type="text"
                                                         size="small"
-                                                        onClick={() => setTimeToolsConfigModal(true)}
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            setTimeToolsConfigModal(true);
+                                                        }}
                                                         style={{
                                                             color: currentTheme.token?.colorPrimary,
                                                             borderColor: currentTheme.token?.colorPrimary,
@@ -629,7 +619,10 @@ const MCPToolsManagement: React.FC = () => {
                                                     <Button
                                                         type="text"
                                                         size="small"
-                                                        onClick={() => setCacheToolsConfigModal(true)}
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            setCacheToolsConfigModal(true);
+                                                        }}
                                                         style={{
                                                             color: currentTheme.token?.colorPrimary,
                                                             borderColor: currentTheme.token?.colorPrimary,
@@ -652,7 +645,6 @@ const MCPToolsManagement: React.FC = () => {
                                                 </Tooltip>
                                             )}
                                         </Space>
-                                        <div></div>
                                     </div>
                                 ),
                                 extra: (

--- a/frontend/src/pages/MCPToolsManagement.tsx
+++ b/frontend/src/pages/MCPToolsManagement.tsx
@@ -18,7 +18,9 @@ import {
   Typography,
   Empty,
   Collapse,
-  App
+  App,
+  Card,
+  Descriptions
 } from 'antd';
 import {
   ProCard,
@@ -54,7 +56,7 @@ const MCPToolsManagement: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [tools, setTools] = useState<MCPToolInfo[]>([]);
   const [categories, setCategories] = useState<MCPCategoryInfo[]>([]);
-  // const [status, setStatus] = useState<MCPStatusResponse['data'] | null>(null);
+  const [status, setStatus] = useState<MCPStatusResponse['data'] | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
   const [toolDetailModal, setToolDetailModal] = useState<{
     visible: boolean;

--- a/frontend/src/pages/MCPToolsManagement.tsx
+++ b/frontend/src/pages/MCPToolsManagement.tsx
@@ -1,816 +1,849 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {
-  Button,
-  Switch,
-  Tag,
-  Space,
-  Modal,
-  Form,
-  Input,
-  Select,
-  Badge,
-  Tooltip,
-  Divider,
-  Row,
-  Col,
-  Alert,
-  Spin,
-  Typography,
-  Empty,
-  Collapse,
-  App,
-  Card,
-  Descriptions
+    Alert,
+    App,
+    Badge,
+    Button,
+    Col,
+    Collapse,
+    Divider,
+    Empty,
+    Form,
+    Input,
+    Modal,
+    Row,
+    Select,
+    Space,
+    Spin,
+    Switch,
+    Tag,
+    Tooltip,
+    Typography
 } from 'antd';
+import {ProCard, ProDescriptions} from '@ant-design/pro-components';
 import {
-  ProCard,
-  ProDescriptions
-} from '@ant-design/pro-components';
-import {
-  ToolOutlined,
-  ReloadOutlined,
-  InfoCircleOutlined,
-  BugOutlined,
-  ApiOutlined,
-  CheckCircleOutlined,
-  ExclamationCircleOutlined,
-  FilterOutlined,
-  SettingOutlined
+    ApiOutlined,
+    BugOutlined,
+    CheckCircleOutlined,
+    ExclamationCircleOutlined,
+    FilterOutlined,
+    InfoCircleOutlined,
+    ReloadOutlined,
+    SettingOutlined
 } from '@ant-design/icons';
-import { apiClient, MCPToolInfo, MCPCategoryInfo, MCPStatusResponse } from '../api';
-import { useTheme } from '../contexts/ThemeContext';
+import {apiClient, MCPCategoryInfo, MCPStatusResponse, MCPToolInfo} from '../api';
+import {useTheme} from '../contexts/ThemeContext';
 import FileToolsConfigModal from '../components/FileTools/FileToolsConfigModal';
 import TimeToolsConfigModal from '../components/TimeTools/TimeToolsConfigModal';
 import CacheToolsConfigModal from '../components/CacheTools/CacheToolsConfigModal';
 import './MCPToolsManagement.css';
 
-const { Title, Text, Paragraph } = Typography;
-const { Option } = Select;
-const { TextArea } = Input;
-const { useApp } = App;
+const {Title, Text, Paragraph} = Typography;
+const {Option} = Select;
+const {TextArea} = Input;
+const {useApp} = App;
 
 const MCPToolsManagement: React.FC = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { currentTheme, themeType } = useTheme();
-  const { message: messageApi } = useApp();
-  const [loading, setLoading] = useState(false);
-  const [tools, setTools] = useState<MCPToolInfo[]>([]);
-  const [categories, setCategories] = useState<MCPCategoryInfo[]>([]);
-  const [status, setStatus] = useState<MCPStatusResponse['data'] | null>(null);
-  const [selectedCategory, setSelectedCategory] = useState<string>('all');
-  const [toolDetailModal, setToolDetailModal] = useState<{
-    visible: boolean;
-    tool: MCPToolInfo | null;
-  }>({ visible: false, tool: null });
-  const [testToolModal, setTestToolModal] = useState<{
-    visible: boolean;
-    tool: MCPToolInfo | null;
-    form: any;
-  }>({ visible: false, tool: null, form: null });
-  const [testResult, setTestResult] = useState<string>('');
-  const [fileToolsConfigModal, setFileToolsConfigModal] = useState(false);
-  const [timeToolsConfigModal, setTimeToolsConfigModal] = useState(false);
-  const [cacheToolsConfigModal, setCacheToolsConfigModal] = useState(false);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {currentTheme, themeType} = useTheme();
+    const {message: messageApi} = useApp();
+    const [loading, setLoading] = useState(false);
+    const [tools, setTools] = useState<MCPToolInfo[]>([]);
+    const [categories, setCategories] = useState<MCPCategoryInfo[]>([]);
+    const [status, setStatus] = useState<MCPStatusResponse['data'] | null>(null);
+    const [selectedCategory, setSelectedCategory] = useState<string>('all');
+    const [toolDetailModal, setToolDetailModal] = useState<{
+        visible: boolean;
+        tool: MCPToolInfo | null;
+    }>({visible: false, tool: null});
+    const [testToolModal, setTestToolModal] = useState<{
+        visible: boolean;
+        tool: MCPToolInfo | null;
+        form: any;
+    }>({visible: false, tool: null, form: null});
+    const [testResult, setTestResult] = useState<string>('');
+    const [fileToolsConfigModal, setFileToolsConfigModal] = useState(false);
+    const [timeToolsConfigModal, setTimeToolsConfigModal] = useState(false);
+    const [cacheToolsConfigModal, setCacheToolsConfigModal] = useState(false);
 
-  const [form] = Form.useForm();
+    const [form] = Form.useForm();
 
-  // 加载数据
-  const loadData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const [statusRes, categoriesRes, toolsRes] = await Promise.all([
-        apiClient.getMCPStatus().catch(e => ({ success: false, data: null })),
-        apiClient.getMCPCategories().catch(e => ({ success: false, data: { categories: [], total_categories: 0 } })),
-        apiClient.getMCPTools().catch(e => ({ success: false, data: { tools: [], server: '', organization: '' } }))
-      ]);
+    // 加载数据
+    const loadData = useCallback(async () => {
+        setLoading(true);
+        try {
+            const [statusRes, categoriesRes, toolsRes] = await Promise.all([
+                apiClient.getMCPStatus().catch(e => ({success: false, data: null})),
+                apiClient.getMCPCategories().catch(e => ({
+                    success: false,
+                    data: {categories: [], total_categories: 0}
+                })),
+                apiClient.getMCPTools().catch(e => ({success: false, data: {tools: [], server: '', organization: ''}}))
+            ]);
 
-      // if (statusRes.success && statusRes.data) {
-      //   setStatus(statusRes.data);
-      // }
+            // if (statusRes.success && statusRes.data) {
+            //   setStatus(statusRes.data);
+            // }
 
-      if (categoriesRes.success && categoriesRes.data) {
-        setCategories(categoriesRes.data.categories);
-      }
+            if (categoriesRes.success && categoriesRes.data) {
+                setCategories(categoriesRes.data.categories);
+            }
 
-      if (toolsRes.success && toolsRes.data && Array.isArray((toolsRes.data as any).tools)) {
-        setTools((toolsRes.data as any).tools);
-      } else {
-        // 如果API不可用，使用模拟数据
-        const mockTools: MCPToolInfo[] = [
-          {
-            id: '1',
-            name: 'get_current_timestamp',
-            description: '获取当前时间戳，支持多种时间格式',
-            category: 'time',
-            schema: { type: 'object', properties: { format: { type: 'string', enum: ['iso', 'unix', 'formatted'] } } },
-            enabled: true,
-            implementation_type: 'builtin',
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            metadata: { tags: ['时间', '时间戳', '格式化'] }
-          },
-          {
-            id: '2',
-            name: 'get_system_info',
-            description: '获取LazyAI Studio系统信息，包括CPU、内存、操作系统等',
-            category: 'system',
-            schema: { type: 'object', properties: { detailed: { type: 'boolean' }, include_performance: { type: 'boolean' } } },
-            enabled: true,
-            implementation_type: 'builtin',
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            metadata: { tags: ['系统', '监控', '性能'] }
-          },
-          {
-            id: '5',
-            name: 'health_check',
-            description: '执行系统健康检查，验证各组件状态',
-            category: 'system',
-            schema: { type: 'object', properties: { check_database: { type: 'boolean' }, check_cache: { type: 'boolean' } } },
-            enabled: true,
-            implementation_type: 'builtin',
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            metadata: { tags: ['健康检查', '监控', '诊断'] }
-          },
-          {
-            id: '6',
-            name: 'read_file',
-            description: '读取文件内容，支持多种编码格式',
-            category: 'file',
-            schema: { type: 'object', properties: { file_path: { type: 'string' }, encoding: { type: 'string' }, max_lines: { type: 'number' } } },
-            enabled: true,
-            implementation_type: 'builtin',
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            metadata: { tags: ['文件', '读取', 'I/O'] }
-          },
-          {
-            id: '7',
-            name: 'write_file',
-            description: '写入或追加内容到文件',
-            category: 'file',
-            schema: { type: 'object', properties: { file_path: { type: 'string' }, content: { type: 'string' }, mode: { type: 'string' } } },
-            enabled: true,
-            implementation_type: 'builtin',
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            metadata: { tags: ['文件', '写入', 'I/O'] }
-          },
-          {
-            id: '8',
-            name: 'list_directory',
-            description: '列出目录内容，支持递归和详细信息',
-            category: 'file',
-            schema: { type: 'object', properties: { directory_path: { type: 'string' }, show_hidden: { type: 'boolean' }, recursive: { type: 'boolean' } } },
-            enabled: false,
-            implementation_type: 'builtin',
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            metadata: { tags: ['目录', '浏览', '文件系统'] }
-          },
-          {
-            id: '9',
-            name: 'file_info',
-            description: '获取文件详细信息和元数据',
-            category: 'file',
-            schema: { type: 'object', properties: { file_path: { type: 'string' }, checksum: { type: 'boolean' } } },
-            enabled: true,
-            implementation_type: 'builtin',
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            metadata: { tags: ['文件信息', '元数据', '校验'] }
-          }
-        ];
+            if (toolsRes.success && toolsRes.data && Array.isArray((toolsRes.data as any).tools)) {
+                setTools((toolsRes.data as any).tools);
+            } else {
+                // 如果API不可用，使用模拟数据
+                const mockTools: MCPToolInfo[] = [
+                    {
+                        id: '1',
+                        name: 'get_current_timestamp',
+                        description: '获取当前时间戳，支持多种时间格式',
+                        category: 'time',
+                        schema: {
+                            type: 'object',
+                            properties: {format: {type: 'string', enum: ['iso', 'unix', 'formatted']}}
+                        },
+                        enabled: true,
+                        implementation_type: 'builtin',
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString(),
+                        metadata: {tags: ['时间', '时间戳', '格式化']}
+                    },
+                    {
+                        id: '2',
+                        name: 'get_system_info',
+                        description: '获取LazyAI Studio系统信息，包括CPU、内存、操作系统等',
+                        category: 'system',
+                        schema: {
+                            type: 'object',
+                            properties: {detailed: {type: 'boolean'}, include_performance: {type: 'boolean'}}
+                        },
+                        enabled: true,
+                        implementation_type: 'builtin',
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString(),
+                        metadata: {tags: ['系统', '监控', '性能']}
+                    },
+                    {
+                        id: '5',
+                        name: 'health_check',
+                        description: '执行系统健康检查，验证各组件状态',
+                        category: 'system',
+                        schema: {
+                            type: 'object',
+                            properties: {check_database: {type: 'boolean'}, check_cache: {type: 'boolean'}}
+                        },
+                        enabled: true,
+                        implementation_type: 'builtin',
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString(),
+                        metadata: {tags: ['健康检查', '监控', '诊断']}
+                    },
+                    {
+                        id: '6',
+                        name: 'read_file',
+                        description: '读取文件内容，支持多种编码格式',
+                        category: 'file',
+                        schema: {
+                            type: 'object',
+                            properties: {
+                                file_path: {type: 'string'},
+                                encoding: {type: 'string'},
+                                max_lines: {type: 'number'}
+                            }
+                        },
+                        enabled: true,
+                        implementation_type: 'builtin',
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString(),
+                        metadata: {tags: ['文件', '读取', 'I/O']}
+                    },
+                    {
+                        id: '7',
+                        name: 'write_file',
+                        description: '写入或追加内容到文件',
+                        category: 'file',
+                        schema: {
+                            type: 'object',
+                            properties: {file_path: {type: 'string'}, content: {type: 'string'}, mode: {type: 'string'}}
+                        },
+                        enabled: true,
+                        implementation_type: 'builtin',
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString(),
+                        metadata: {tags: ['文件', '写入', 'I/O']}
+                    },
+                    {
+                        id: '8',
+                        name: 'list_directory',
+                        description: '列出目录内容，支持递归和详细信息',
+                        category: 'file',
+                        schema: {
+                            type: 'object',
+                            properties: {
+                                directory_path: {type: 'string'},
+                                show_hidden: {type: 'boolean'},
+                                recursive: {type: 'boolean'}
+                            }
+                        },
+                        enabled: false,
+                        implementation_type: 'builtin',
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString(),
+                        metadata: {tags: ['目录', '浏览', '文件系统']}
+                    },
+                    {
+                        id: '9',
+                        name: 'file_info',
+                        description: '获取文件详细信息和元数据',
+                        category: 'file',
+                        schema: {
+                            type: 'object',
+                            properties: {file_path: {type: 'string'}, checksum: {type: 'boolean'}}
+                        },
+                        enabled: true,
+                        implementation_type: 'builtin',
+                        created_at: new Date().toISOString(),
+                        updated_at: new Date().toISOString(),
+                        metadata: {tags: ['文件信息', '元数据', '校验']}
+                    }
+                ];
 
-        const mockCategories: MCPCategoryInfo[] = [
-          { id: 'system', name: '系统工具', description: '系统信息和监控相关工具', icon: '🖥️', enabled: true },
-          { id: 'time', name: '时间工具', description: '时间戳和日期相关工具', icon: '⏰', enabled: true },
-          { id: 'file', name: '文件工具', description: '文件和目录操作相关工具', icon: '📁', enabled: true },
-          { id: 'cache', name: '缓存工具', description: 'Redis风格的缓存操作相关工具', icon: '🗄️', enabled: true }
-        ];
+                const mockCategories: MCPCategoryInfo[] = [
+                    {id: 'system', name: '系统工具', description: '系统信息和监控相关工具', icon: '🖥️', enabled: true},
+                    {id: 'time', name: '时间工具', description: '时间戳和日期相关工具', icon: '⏰', enabled: true},
+                    {id: 'file', name: '文件工具', description: '文件和目录操作相关工具', icon: '📁', enabled: true},
+                    {
+                        id: 'cache',
+                        name: '缓存工具',
+                        description: 'Redis风格的缓存操作相关工具',
+                        icon: '🗄️',
+                        enabled: true
+                    }
+                ];
 
-        setTools(mockTools);
-        setCategories(mockCategories);
-        setStatus({
-          status: 'healthy',
-          server_name: 'LazyAI Studio MCP Server',
-          tools_count: mockTools.filter(t => t.enabled).length,
-          total_tools: mockTools.length,
-          categories_count: mockCategories.length,
-          tools_by_category: {
-            system: 2,
-            time: 1,
-            file: 4
-          },
-          endpoints: {},
-          organization: 'LazyGophers',
-          motto: '让 AI 替你思考，让工具替你工作！',
-          last_updated: new Date().toISOString()
-        });
-      }
-    } catch (error) {
-      console.error('Failed to load MCP data:', error);
-      messageApi.error('加载MCP工具数据失败');
-    } finally {
-      setLoading(false);
-    }
-  }, [messageApi]);
-
-  // 切换工具开关状态
-  const toggleTool = async (tool: MCPToolInfo, enabled: boolean) => {
-    try {
-      const response = enabled
-        ? await apiClient.enableMCPTool(tool.name)
-        : await apiClient.disableMCPTool(tool.name);
-
-      if (response.success) {
-        messageApi.success(`工具${tool.name}已${enabled ? '启用' : '禁用'}`);
-        loadData(); // 重新加载数据
-      } else {
-        messageApi.error(response.message);
-      }
-    } catch (error) {
-      // 模拟状态切换（用于演示）
-      setTools(prevTools =>
-        prevTools.map(t =>
-          t.id === tool.id ? { ...t, enabled } : t
-        )
-      );
-      messageApi.success(`工具${tool.name}已${enabled ? '启用' : '禁用'}`);
-    }
-  };
-
-  // 切换分类开关状态
-  const toggleCategory = async (category: MCPCategoryInfo, enabled: boolean) => {
-    try {
-      const response = enabled
-        ? await apiClient.enableMCPCategory(category.id)
-        : await apiClient.disableMCPCategory(category.id);
-
-      if (response.success) {
-        messageApi.success(`分类${category.name}已${enabled ? '启用' : '禁用'}`);
-        loadData(); // 重新加载数据
-      } else {
-        messageApi.error(response.message);
-      }
-    } catch (error) {
-      // 模拟状态切换（用于演示）
-      setCategories(prevCategories =>
-        prevCategories.map(c =>
-          c.id === category.id ? { ...c, enabled } : c
-        )
-      );
-      messageApi.success(`分类${category.name}已${enabled ? '启用' : '禁用'}`);
-    }
-  };
-
-  // 测试工具
-  const testTool = async (tool: MCPToolInfo, params: any) => {
-    try {
-      setLoading(true);
-      const response = await apiClient.callMCPTool(tool.name, params);
-      
-      if (response.success) {
-        setTestResult(JSON.stringify(response.data, null, 2));
-        messageApi.success('工具测试成功');
-      } else {
-        setTestResult(`Error: ${response.message}`);
-        messageApi.error('工具测试失败');
-      }
-    } catch (error) {
-      setTestResult(`Error: ${error}`);
-      messageApi.error('工具测试失败');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // 刷新工具配置
-  const refreshTools = async () => {
-    try {
-      setLoading(true);
-      const response = await apiClient.refreshMCPTools();
-      
-      if (response.success) {
-        messageApi.success('工具配置已刷新');
-        loadData();
-      } else {
-        messageApi.error(response.message);
-      }
-    } catch (error) {
-      messageApi.success('工具配置已刷新'); // 模拟成功
-      loadData();
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
-
-  // 按分类分组工具
-  const getToolsByCategory = () => {
-    const grouped: { [key: string]: MCPToolInfo[] } = {};
-    
-    // 初始化所有分类
-    categories.forEach(category => {
-      grouped[category.id] = [];
-    });
-    
-    // 分组工具 - 确保 tools 是数组
-    if (Array.isArray(tools)) {
-      tools.forEach(tool => {
-        if (!grouped[tool.category]) {
-          grouped[tool.category] = [];
+                setTools(mockTools);
+                setCategories(mockCategories);
+                setStatus({
+                    status: 'healthy',
+                    server_name: 'LazyAI Studio MCP Server',
+                    tools_count: mockTools.filter(t => t.enabled).length,
+                    total_tools: mockTools.length,
+                    categories_count: mockCategories.length,
+                    tools_by_category: {
+                        system: 2,
+                        time: 1,
+                        file: 4
+                    },
+                    endpoints: {},
+                    organization: 'LazyGophers',
+                    motto: '让 AI 替你思考，让工具替你工作！',
+                    last_updated: new Date().toISOString()
+                });
+            }
+        } catch (error) {
+            console.error('Failed to load MCP data:', error);
+            messageApi.error('加载MCP工具数据失败');
+        } finally {
+            setLoading(false);
         }
-        grouped[tool.category].push(tool);
-      });
-    }
-    
-    return grouped;
-  };
+    }, [messageApi]);
 
+    // 切换工具开关状态
+    const toggleTool = async (tool: MCPToolInfo, enabled: boolean) => {
+        try {
+            const response = enabled
+                ? await apiClient.enableMCPTool(tool.name)
+                : await apiClient.disableMCPTool(tool.name);
 
-  // 过滤工具
-  const toolsByCategory = getToolsByCategory();
-  
-  // 显示所有分类（包括禁用的），但只有启用的分类会显示工具
-  const filteredCategories = selectedCategory === 'all' 
-    ? categories
-    : categories.filter(cat => cat.id === selectedCategory);
-
-  // 渲染工具卡片
-  const renderToolCard = (tool: MCPToolInfo) => {
-    const categoryInfo = categories.find(c => c.id === tool.category);
-    
-    // 使用主题token来获取颜色
-    const token = currentTheme.token;
-    const enabledBg = tool.enabled ? token?.colorSuccessBg || '#f6ffed' : token?.colorFillTertiary || '#f5f5f5';
-    const enabledBorder = tool.enabled ? token?.colorSuccess || '#52c41a' : token?.colorBorderSecondary || '#d9d9d9';
-    const cardBorder = tool.enabled ? token?.colorBorder || '#d9d9d9' : token?.colorBorderSecondary || '#f0f0f0';
-    
-    // 根据主题类型确定描述文字颜色，确保在所有主题下都可读
-    const isDarkTheme = themeType === 'nightRain' || themeType === 'plumRain' || 
-                       themeType === 'deepSeaMoon' || themeType === 'greenMountain';
-    const descriptionColor = token?.colorTextSecondary || 
-                            (isDarkTheme ? 'rgba(255, 255, 255, 0.65)' : 'rgba(0, 0, 0, 0.65)');
-    
-    return (
-      <Col xs={24} sm={12} lg={8} xl={6} key={tool.id}>
-        <ProCard
-          size="small"
-          hoverable
-          className={`tool-card ${!tool.enabled ? 'disabled' : ''}`}
-          style={{
-            height: '100%',
-            opacity: tool.enabled ? 1 : 0.6,
-            borderColor: cardBorder,
-            backgroundColor: token?.colorBgContainer
-          }}
-          title={
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <div style={{
-                  width: 32,
-                  height: 32,
-                  borderRadius: '50%',
-                  backgroundColor: enabledBg,
-                  border: `2px solid ${enabledBorder}`,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: '14px'
-                }}>
-                  {categoryInfo?.icon || '🔧'}
-                </div>
-                <Text strong style={{ fontSize: 14, color: token?.colorText }}>{tool.name}</Text>
-              </div>
-              <Tag color={tool.implementation_type === 'builtin' ? 'blue' : 'green'}>
-                {tool.implementation_type}
-              </Tag>
-            </div>
-          }
-          extra={
-            <Space size="small">
-              <Tooltip title={tool.enabled ? '禁用工具' : '启用工具'}>
-                <Switch
-                  size="small"
-                  checked={tool.enabled}
-                  onChange={(checked) => toggleTool(tool, checked)}
-                  checkedChildren={<CheckCircleOutlined />}
-                  unCheckedChildren={<ExclamationCircleOutlined />}
-                />
-              </Tooltip>
-              <Tooltip title="查看详情">
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<InfoCircleOutlined />}
-                  onClick={() => setToolDetailModal({ visible: true, tool })}
-                />
-              </Tooltip>
-              <Tooltip title={tool.enabled ? '测试工具' : '需要先启用工具'}>
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<BugOutlined />}
-                  disabled={!tool.enabled}
-                  onClick={() => setTestToolModal({ visible: true, tool, form })}
-                />
-              </Tooltip>
-            </Space>
-          }
-        >
-          <div>
-            <Typography.Paragraph
-              ellipsis={{ rows: 2, tooltip: tool.description }}
-              style={{ margin: 0, fontSize: 12, color: descriptionColor }}
-            >
-              {tool.description}
-            </Typography.Paragraph>
-            <div style={{ marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 4 }}>
-              {tool.metadata?.tags?.slice(0, 3).map((tag: string, index: number) => (
-                <Tag key={index} color="geekblue" style={{ fontSize: '11px' }}>{tag}</Tag>
-              ))}
-              {tool.metadata?.tags?.length > 3 && (
-                <Tag color="default" style={{ fontSize: '11px' }}>+{tool.metadata.tags.length - 3}</Tag>
-              )}
-            </div>
-          </div>
-        </ProCard>
-      </Col>
-    );
-  };
-
-  return (
-    <div className="mcp-tools-management" style={{ padding: '0 24px' }}>
-      <div style={{ marginBottom: 24 }}>
-        <Title level={2} style={{ color: currentTheme.token?.colorText }}>
-          <ApiOutlined /> MCP 工具管理
-        </Title>
-        <Paragraph style={{ color: currentTheme.token?.colorTextSecondary }}>
-          管理 Model Context Protocol (MCP) 工具的启用状态和配置参数
-        </Paragraph>
-      </div>
-
-
-      {/* 工具筛选和操作栏 */}
-      <ProCard style={{ marginBottom: 16 }}>
-        <Row justify="space-between" align="middle">
-          <Col>
-            <Space>
-              <FilterOutlined />
-              <Text>工具分类：</Text>
-              <Select
-                value={selectedCategory}
-                onChange={setSelectedCategory}
-                style={{ width: 160 }}
-              >
-                <Option value="all">所有分类 ({tools.length})</Option>
-                {categories.map(category => {
-                  const count = toolsByCategory[category.id]?.length || 0;
-                  return (
-                    <Option key={category.id} value={category.id} disabled={!category.enabled}>
-                      {category.icon} {category.name} ({count}) {!category.enabled && '(禁用)'}
-                    </Option>
-                  );
-                })}
-              </Select>
-            </Space>
-          </Col>
-          <Col>
-            <Button
-              type="primary"
-              icon={<ReloadOutlined />}
-              onClick={refreshTools}
-              loading={loading}
-            >
-              刷新配置
-            </Button>
-          </Col>
-        </Row>
-      </ProCard>
-
-      {/* 工具分类展示 */}
-      <Spin spinning={loading}>
-        {filteredCategories.length === 0 ? (
-          <Empty description="暂无工具分类" />
-        ) : (
-          <Collapse 
-            defaultActiveKey={selectedCategory === 'all' ? filteredCategories.map(c => c.id) : [selectedCategory]}
-            ghost
-            items={filteredCategories.map(category => {
-              const categoryTools = toolsByCategory[category.id] || [];
-              const enabledCount = categoryTools.filter(t => t.enabled).length;
-              
-              return {
-                key: category.id,
-                label: (
-                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
-                    <Space>
-                      <span style={{ fontSize: '18px', opacity: category.enabled ? 1 : 0.5 }}>{category.icon}</span>
-                      <Title level={4} style={{ margin: 0, opacity: category.enabled ? 1 : 0.5 }}>
-                        {category.name}
-                      </Title>
-                      <Text type="secondary">({enabledCount}/{categoryTools.length})</Text>
-                      <Switch
-                        size="small"
-                        checked={category.enabled}
-                        onChange={(checked) => toggleCategory(category, checked)}
-                        checkedChildren="启用"
-                        unCheckedChildren="禁用"
-                      />
-                      {category.enabled && (
-                        <Tag color={enabledCount === categoryTools.length ? 'success' : enabledCount > 0 ? 'warning' : 'default'}>
-                          {enabledCount === categoryTools.length ? '全部启用' : enabledCount > 0 ? '部分启用' : '全部禁用'}
-                        </Tag>
-                      )}
-                      {!category.enabled && <Tag color="red">分类禁用</Tag>}
-                      {/* 统一的配置按钮样式 */}
-                      {category.id === 'file' && (
-                        <Tooltip title="文件工具安全配置">
-                          <Button
-                            type="text"
-                            size="small"
-                            icon={<SettingOutlined />}
-                            onClick={() => setFileToolsConfigModal(true)}
-                            style={{
-                              color: currentTheme.token?.colorPrimary,
-                              borderColor: currentTheme.token?.colorPrimary,
-                              backgroundColor: 'rgba(24, 144, 255, 0.06)',
-                              borderRadius: 6,
-                              border: `1px solid ${currentTheme.token?.colorPrimary}20`,
-                              transition: 'all 0.2s ease'
-                            }}
-                            onMouseEnter={(e) => {
-                              e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.12)';
-                              e.currentTarget.style.borderColor = currentTheme.token?.colorPrimary || '#1890ff';
-                            }}
-                            onMouseLeave={(e) => {
-                              e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.06)';
-                              e.currentTarget.style.borderColor = `${currentTheme.token?.colorPrimary}20` || '#1890ff20';
-                            }}
-                          >
-                            工具配置
-                          </Button>
-                        </Tooltip>
-                      )}
-                      {category.id === 'time' && (
-                        <Tooltip title="时间工具配置">
-                          <Button
-                            type="text"
-                            size="small"
-                            icon={<SettingOutlined />}
-                            onClick={() => setTimeToolsConfigModal(true)}
-                            style={{
-                              color: currentTheme.token?.colorPrimary,
-                              borderColor: currentTheme.token?.colorPrimary,
-                              backgroundColor: 'rgba(24, 144, 255, 0.06)',
-                              borderRadius: 6,
-                              border: `1px solid ${currentTheme.token?.colorPrimary}20`,
-                              transition: 'all 0.2s ease'
-                            }}
-                            onMouseEnter={(e) => {
-                              e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.12)';
-                              e.currentTarget.style.borderColor = currentTheme.token?.colorPrimary || '#1890ff';
-                            }}
-                            onMouseLeave={(e) => {
-                              e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.06)';
-                              e.currentTarget.style.borderColor = `${currentTheme.token?.colorPrimary}20` || '#1890ff20';
-                            }}
-                          >
-                            工具配置
-                          </Button>
-                        </Tooltip>
-                      )}
-                      {category.id === 'cache' && (
-                        <Tooltip title="缓存工具配置">
-                          <Button
-                            type="text"
-                            size="small"
-                            icon={<SettingOutlined />}
-                            onClick={() => setCacheToolsConfigModal(true)}
-                            style={{
-                              color: currentTheme.token?.colorPrimary,
-                              borderColor: currentTheme.token?.colorPrimary,
-                              backgroundColor: 'rgba(24, 144, 255, 0.06)',
-                              borderRadius: 6,
-                              border: `1px solid ${currentTheme.token?.colorPrimary}20`,
-                              transition: 'all 0.2s ease'
-                            }}
-                            onMouseEnter={(e) => {
-                              e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.12)';
-                              e.currentTarget.style.borderColor = currentTheme.token?.colorPrimary || '#1890ff';
-                            }}
-                            onMouseLeave={(e) => {
-                              e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.06)';
-                              e.currentTarget.style.borderColor = `${currentTheme.token?.colorPrimary}20` || '#1890ff20';
-                            }}
-                          >
-                            工具配置
-                          </Button>
-                        </Tooltip>
-                      )}
-                    </Space>
-                    <div></div>
-                  </div>
-                ),
-                extra: (
-                  <Text type="secondary" style={{ fontSize: 12 }}>
-                    {category.description}
-                  </Text>
-                ),
-                children: !category.enabled ? (
-                  <Alert
-                    message="分类已禁用"
-                    description={`${category.name} 分类当前处于禁用状态。启用分类以查看和管理其中的工具。`}
-                    type="warning"
-                    showIcon
-                    style={{ margin: '16px 0' }}
-                  />
-                ) : categoryTools.length === 0 ? (
-                  <Empty 
-                    description={`${category.name} 分类下暂无工具`}
-                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  />
-                ) : (
-                  <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
-                    {categoryTools.map(renderToolCard)}
-                  </Row>
+            if (response.success) {
+                messageApi.success(`工具${tool.name}已${enabled ? '启用' : '禁用'}`);
+                loadData(); // 重新加载数据
+            } else {
+                messageApi.error(response.message);
+            }
+        } catch (error) {
+            // 模拟状态切换（用于演示）
+            setTools(prevTools =>
+                prevTools.map(t =>
+                    t.id === tool.id ? {...t, enabled} : t
                 )
-              };
-            })}
-          />
-        )}
-      </Spin>
-
-      {/* 工具详情Modal */}
-      <Modal
-        title={
-          <Space>
-            <ToolOutlined />
-            工具详情
-          </Space>
+            );
+            messageApi.success(`工具${tool.name}已${enabled ? '启用' : '禁用'}`);
         }
-        open={toolDetailModal.visible}
-        onCancel={() => setToolDetailModal({ visible: false, tool: null })}
-        footer={null}
-        width={700}
-      >
-        {toolDetailModal.tool && (
-          <div>
-            <ProDescriptions
-              column={2}
-              bordered
-              dataSource={{
-                '工具名称': toolDetailModal.tool.name,
-                '状态': (
-                  <Badge
-                    status={toolDetailModal.tool.enabled ? 'success' : 'default'}
-                    text={toolDetailModal.tool.enabled ? '启用' : '禁用'}
-                  />
-                ),
-                '分类': categories.find(c => c.id === toolDetailModal.tool!.category)?.name || toolDetailModal.tool.category,
-                '描述': toolDetailModal.tool.description,
-                '实现类型': toolDetailModal.tool.implementation_type,
-                '创建时间': new Date(toolDetailModal.tool.created_at).toLocaleString(),
-              }}
-            />
+    };
 
-            <Divider />
+    // 切换分类开关状态
+    const toggleCategory = async (category: MCPCategoryInfo, enabled: boolean) => {
+        try {
+            const response = enabled
+                ? await apiClient.enableMCPCategory(category.id)
+                : await apiClient.disableMCPCategory(category.id);
 
-            <Title level={4}>Schema 定义</Title>
-            <pre style={{ 
-              background: currentTheme.token?.colorFillQuaternary || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.04)' : 'rgba(0, 0, 0, 0.02)'), 
-              border: `1px solid ${currentTheme.token?.colorBorder || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.06)')}`,
-              color: currentTheme.token?.colorText || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.85)'),
-              padding: 16, 
-              borderRadius: 6,
-              fontSize: 12,
-              overflow: 'auto'
-            }}>
+            if (response.success) {
+                messageApi.success(`分类${category.name}已${enabled ? '启用' : '禁用'}`);
+                loadData(); // 重新加载数据
+            } else {
+                messageApi.error(response.message);
+            }
+        } catch (error) {
+            // 模拟状态切换（用于演示）
+            setCategories(prevCategories =>
+                prevCategories.map(c =>
+                    c.id === category.id ? {...c, enabled} : c
+                )
+            );
+            messageApi.success(`分类${category.name}已${enabled ? '启用' : '禁用'}`);
+        }
+    };
+
+    // 测试工具
+    const testTool = async (tool: MCPToolInfo, params: any) => {
+        try {
+            setLoading(true);
+            const response = await apiClient.callMCPTool(tool.name, params);
+
+            if (response.success) {
+                setTestResult(JSON.stringify(response.data, null, 2));
+                messageApi.success('工具测试成功');
+            } else {
+                setTestResult(`Error: ${response.message}`);
+                messageApi.error('工具测试失败');
+            }
+        } catch (error) {
+            setTestResult(`Error: ${error}`);
+            messageApi.error('工具测试失败');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // 刷新工具配置
+    const refreshTools = async () => {
+        try {
+            setLoading(true);
+            const response = await apiClient.refreshMCPTools();
+
+            if (response.success) {
+                messageApi.success('工具配置已刷新');
+                loadData();
+            } else {
+                messageApi.error(response.message);
+            }
+        } catch (error) {
+            messageApi.success('工具配置已刷新'); // 模拟成功
+            loadData();
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadData();
+    }, [loadData]);
+
+    // 按分类分组工具
+    const getToolsByCategory = () => {
+        const grouped: { [key: string]: MCPToolInfo[] } = {};
+
+        // 初始化所有分类
+        categories.forEach(category => {
+            grouped[category.id] = [];
+        });
+
+        // 分组工具 - 确保 tools 是数组
+        if (Array.isArray(tools)) {
+            tools.forEach(tool => {
+                if (!grouped[tool.category]) {
+                    grouped[tool.category] = [];
+                }
+                grouped[tool.category].push(tool);
+            });
+        }
+
+        return grouped;
+    };
+
+
+    // 过滤工具
+    const toolsByCategory = getToolsByCategory();
+
+    // 显示所有分类（包括禁用的），但只有启用的分类会显示工具
+    const filteredCategories = selectedCategory === 'all'
+        ? categories
+        : categories.filter(cat => cat.id === selectedCategory);
+
+    // 渲染工具卡片
+    const renderToolCard = (tool: MCPToolInfo) => {
+        const categoryInfo = categories.find(c => c.id === tool.category);
+
+        // 使用主题token来获取颜色
+        const token = currentTheme.token;
+        const enabledBg = tool.enabled ? token?.colorSuccessBg || '#f6ffed' : token?.colorFillTertiary || '#f5f5f5';
+        const enabledBorder = tool.enabled ? token?.colorSuccess || '#52c41a' : token?.colorBorderSecondary || '#d9d9d9';
+        const cardBorder = tool.enabled ? token?.colorBorder || '#d9d9d9' : token?.colorBorderSecondary || '#f0f0f0';
+
+        // 根据主题类型确定描述文字颜色，确保在所有主题下都可读
+        const isDarkTheme = themeType === 'nightRain' || themeType === 'plumRain' ||
+            themeType === 'deepSeaMoon' || themeType === 'greenMountain';
+        const descriptionColor = token?.colorTextSecondary ||
+            (isDarkTheme ? 'rgba(255, 255, 255, 0.65)' : 'rgba(0, 0, 0, 0.65)');
+
+        return (
+            <Col xs={24} sm={12} lg={8} xl={6} key={tool.id}>
+                <ProCard
+                    size="small"
+                    hoverable
+                    className={`tool-card ${!tool.enabled ? 'disabled' : ''}`}
+                    style={{
+                        height: '100%',
+                        opacity: tool.enabled ? 1 : 0.6,
+                        borderColor: cardBorder,
+                        backgroundColor: token?.colorBgContainer
+                    }}
+                    title={
+                        <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+                            <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
+                                <div style={{
+                                    width: 32,
+                                    height: 32,
+                                    borderRadius: '50%',
+                                    backgroundColor: enabledBg,
+                                    border: `2px solid ${enabledBorder}`,
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    fontSize: '14px'
+                                }}>
+                                    {categoryInfo?.icon || '🔧'}
+                                </div>
+                                <Text strong style={{fontSize: 14, color: token?.colorText}}>{tool.name}</Text>
+                            </div>
+                            <Tag color={tool.implementation_type === 'builtin' ? 'blue' : 'green'}>
+                                {tool.implementation_type}
+                            </Tag>
+                        </div>
+                    }
+                    extra={
+                        <Space size="small">
+                            <Tooltip title={tool.enabled ? '禁用工具' : '启用工具'}>
+                                <Switch
+                                    size="small"
+                                    checked={tool.enabled}
+                                    onChange={(checked) => toggleTool(tool, checked)}
+                                    checkedChildren={<CheckCircleOutlined/>}
+                                    unCheckedChildren={<ExclamationCircleOutlined/>}
+                                />
+                            </Tooltip>
+                            <Tooltip title="查看详情">
+                                <Button
+                                    type="text"
+                                    size="small"
+                                    icon={<InfoCircleOutlined/>}
+                                    onClick={() => setToolDetailModal({visible: true, tool})}
+                                />
+                            </Tooltip>
+                            <Tooltip title={tool.enabled ? '测试工具' : '需要先启用工具'}>
+                                <Button
+                                    type="text"
+                                    size="small"
+                                    icon={<BugOutlined/>}
+                                    disabled={!tool.enabled}
+                                    onClick={() => setTestToolModal({visible: true, tool, form})}
+                                />
+                            </Tooltip>
+                        </Space>
+                    }
+                >
+                    <div>
+                        <Typography.Paragraph
+                            ellipsis={{rows: 2, tooltip: tool.description}}
+                            style={{margin: 0, fontSize: 12, color: descriptionColor}}
+                        >
+                            {tool.description}
+                        </Typography.Paragraph>
+                        <div style={{marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 4}}>
+                            {tool.metadata?.tags?.slice(0, 3).map((tag: string, index: number) => (
+                                <Tag key={index} color="geekblue" style={{fontSize: '11px'}}>{tag}</Tag>
+                            ))}
+                            {tool.metadata?.tags?.length > 3 && (
+                                <Tag color="default" style={{fontSize: '11px'}}>+{tool.metadata.tags.length - 3}</Tag>
+                            )}
+                        </div>
+                    </div>
+                </ProCard>
+            </Col>
+        );
+    };
+
+    return (
+        <div className="mcp-tools-management" style={{padding: '0 24px'}}>
+            <div style={{marginBottom: 24}}>
+                <Title level={2} style={{color: currentTheme.token?.colorText}}>
+                    <ApiOutlined/> MCP 工具管理
+                </Title>
+                <Paragraph style={{color: currentTheme.token?.colorTextSecondary}}>
+                    管理 Model Context Protocol (MCP) 工具的启用状态和配置参数
+                </Paragraph>
+            </div>
+
+
+            {/* 工具筛选和操作栏 */}
+            <ProCard style={{marginBottom: 16}}>
+                <Row justify="space-between" align="middle">
+                    <Col>
+                        <Space>
+                            <FilterOutlined/>
+                            <Text>工具分类：</Text>
+                            <Select
+                                value={selectedCategory}
+                                onChange={setSelectedCategory}
+                                style={{width: 160}}
+                            >
+                                <Option value="all">所有分类 ({tools.length})</Option>
+                                {categories.map(category => {
+                                    const count = toolsByCategory[category.id]?.length || 0;
+                                    return (
+                                        <Option key={category.id} value={category.id} disabled={!category.enabled}>
+                                            {category.icon} {category.name} ({count}) {!category.enabled && '(禁用)'}
+                                        </Option>
+                                    );
+                                })}
+                            </Select>
+                        </Space>
+                    </Col>
+                    <Col>
+                        <Button
+                            type="primary"
+                            icon={<ReloadOutlined/>}
+                            onClick={refreshTools}
+                            loading={loading}
+                        >
+                            刷新配置
+                        </Button>
+                    </Col>
+                </Row>
+            </ProCard>
+
+            {/* 工具分类展示 */}
+            <Spin spinning={loading}>
+                {filteredCategories.length === 0 ? (
+                    <Empty description="暂无工具分类"/>
+                ) : (
+                    <Collapse
+                        defaultActiveKey={selectedCategory === 'all' ? filteredCategories.map(c => c.id) : [selectedCategory]}
+                        ghost
+                        items={filteredCategories.map(category => {
+                            const categoryTools = toolsByCategory[category.id] || [];
+                            const enabledCount = categoryTools.filter(t => t.enabled).length;
+
+                            return {
+                                key: category.id,
+                                label: (
+                                    <div style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'space-between',
+                                        width: '100%'
+                                    }}>
+                                        <Space>
+                                            <span style={{
+                                                fontSize: '18px',
+                                                opacity: category.enabled ? 1 : 0.5
+                                            }}>{category.icon}</span>
+                                            <Title level={4} style={{margin: 0, opacity: category.enabled ? 1 : 0.5}}>
+                                                {category.name}
+                                            </Title>
+                                            <Text type="secondary">({enabledCount}/{categoryTools.length})</Text>
+                                            <Switch
+                                                size="small"
+                                                checked={category.enabled}
+                                                onChange={(checked) => toggleCategory(category, checked)}
+                                                checkedChildren="启用"
+                                                unCheckedChildren="禁用"
+                                            />
+                                            {category.enabled && (
+                                                <Tag
+                                                    color={enabledCount === categoryTools.length ? 'success' : enabledCount > 0 ? 'warning' : 'default'}>
+                                                    {enabledCount === categoryTools.length ? '全部启用' : enabledCount > 0 ? '部分启用' : '全部禁用'}
+                                                </Tag>
+                                            )}
+                                            {!category.enabled && <Tag color="red">分类禁用</Tag>}
+                                            {/* 统一的配置按钮样式 */}
+                                            {category.id === 'file' && (
+                                                <Tooltip title="文件工具安全配置">
+                                                    <Button
+                                                        type="text"
+                                                        size="small"
+                                                        onClick={() => setFileToolsConfigModal(true)}
+                                                        style={{
+                                                            color: currentTheme.token?.colorPrimary,
+                                                            borderColor: currentTheme.token?.colorPrimary,
+                                                            backgroundColor: 'rgba(24, 144, 255, 0.06)',
+                                                            borderRadius: 6,
+                                                            border: `1px solid ${currentTheme.token?.colorPrimary}20`,
+                                                            transition: 'all 0.2s ease'
+                                                        }}
+                                                        onMouseEnter={(e) => {
+                                                            e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.12)';
+                                                            e.currentTarget.style.borderColor = currentTheme.token?.colorPrimary || '#1890ff';
+                                                        }}
+                                                        onMouseLeave={(e) => {
+                                                            e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.06)';
+                                                            e.currentTarget.style.borderColor = `${currentTheme.token?.colorPrimary}20` || '#1890ff20';
+                                                        }}
+                                                    >
+                                                        工具配置
+                                                    </Button>
+                                                </Tooltip>
+                                            )}
+                                            {category.id === 'time' && (
+                                                <Tooltip title="时间工具配置">
+                                                    <Button
+                                                        type="text"
+                                                        size="small"
+                                                        onClick={() => setTimeToolsConfigModal(true)}
+                                                        style={{
+                                                            color: currentTheme.token?.colorPrimary,
+                                                            borderColor: currentTheme.token?.colorPrimary,
+                                                            backgroundColor: 'rgba(24, 144, 255, 0.06)',
+                                                            borderRadius: 6,
+                                                            border: `1px solid ${currentTheme.token?.colorPrimary}20`,
+                                                            transition: 'all 0.2s ease'
+                                                        }}
+                                                        onMouseEnter={(e) => {
+                                                            e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.12)';
+                                                            e.currentTarget.style.borderColor = currentTheme.token?.colorPrimary || '#1890ff';
+                                                        }}
+                                                        onMouseLeave={(e) => {
+                                                            e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.06)';
+                                                            e.currentTarget.style.borderColor = `${currentTheme.token?.colorPrimary}20` || '#1890ff20';
+                                                        }}
+                                                    >
+                                                        工具配置
+                                                    </Button>
+                                                </Tooltip>
+                                            )}
+                                            {category.id === 'cache' && (
+                                                <Tooltip title="缓存工具配置">
+                                                    <Button
+                                                        type="text"
+                                                        size="small"
+                                                        onClick={() => setCacheToolsConfigModal(true)}
+                                                        style={{
+                                                            color: currentTheme.token?.colorPrimary,
+                                                            borderColor: currentTheme.token?.colorPrimary,
+                                                            backgroundColor: 'rgba(24, 144, 255, 0.06)',
+                                                            borderRadius: 6,
+                                                            border: `1px solid ${currentTheme.token?.colorPrimary}20`,
+                                                            transition: 'all 0.2s ease'
+                                                        }}
+                                                        onMouseEnter={(e) => {
+                                                            e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.12)';
+                                                            e.currentTarget.style.borderColor = currentTheme.token?.colorPrimary || '#1890ff';
+                                                        }}
+                                                        onMouseLeave={(e) => {
+                                                            e.currentTarget.style.backgroundColor = 'rgba(24, 144, 255, 0.06)';
+                                                            e.currentTarget.style.borderColor = `${currentTheme.token?.colorPrimary}20` || '#1890ff20';
+                                                        }}
+                                                    >
+                                                        工具配置
+                                                    </Button>
+                                                </Tooltip>
+                                            )}
+                                        </Space>
+                                        <div></div>
+                                    </div>
+                                ),
+                                extra: (
+                                    <Text type="secondary" style={{fontSize: 12}}>
+                                        {category.description}
+                                    </Text>
+                                ),
+                                children: !category.enabled ? (
+                                    <Alert
+                                        message="分类已禁用"
+                                        description={`${category.name} 分类当前处于禁用状态。启用分类以查看和管理其中的工具。`}
+                                        type="warning"
+                                        showIcon
+                                        style={{margin: '16px 0'}}
+                                    />
+                                ) : categoryTools.length === 0 ? (
+                                    <Empty
+                                        description={`${category.name} 分类下暂无工具`}
+                                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                                    />
+                                ) : (
+                                    <Row gutter={[16, 16]} style={{marginTop: 16}}>
+                                        {categoryTools.map(renderToolCard)}
+                                    </Row>
+                                )
+                            };
+                        })}
+                    />
+                )}
+            </Spin>
+
+            {/* 工具详情Modal */}
+            <Modal
+                title="工具详情"
+                open={toolDetailModal.visible}
+                onCancel={() => setToolDetailModal({visible: false, tool: null})}
+                footer={null}
+                width={700}
+            >
+                {toolDetailModal.tool && (
+                    <div>
+                        <ProDescriptions
+                            column={2}
+                            bordered
+                            dataSource={{
+                                '工具名称': toolDetailModal.tool.name,
+                                '状态': (
+                                    <Badge
+                                        status={toolDetailModal.tool.enabled ? 'success' : 'default'}
+                                        text={toolDetailModal.tool.enabled ? '启用' : '禁用'}
+                                    />
+                                ),
+                                '分类': categories.find(c => c.id === toolDetailModal.tool!.category)?.name || toolDetailModal.tool.category,
+                                '描述': toolDetailModal.tool.description,
+                                '实现类型': toolDetailModal.tool.implementation_type,
+                                '创建时间': new Date(toolDetailModal.tool.created_at).toLocaleString(),
+                            }}
+                        />
+
+                        <Divider/>
+
+                        <Title level={4}>Schema 定义</Title>
+                        <pre style={{
+                            background: currentTheme.token?.colorFillQuaternary || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.04)' : 'rgba(0, 0, 0, 0.02)'),
+                            border: `1px solid ${currentTheme.token?.colorBorder || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.06)')}`,
+                            color: currentTheme.token?.colorText || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.85)'),
+                            padding: 16,
+                            borderRadius: 6,
+                            fontSize: 12,
+                            overflow: 'auto'
+                        }}>
               {JSON.stringify(toolDetailModal.tool.schema, null, 2)}
             </pre>
 
-            {toolDetailModal.tool.metadata && (
-              <>
-                <Divider />
-                <Title level={4}>元数据</Title>
-                <pre style={{ 
-                  background: currentTheme.token?.colorFillQuaternary || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.04)' : 'rgba(0, 0, 0, 0.02)'), 
-                  border: `1px solid ${currentTheme.token?.colorBorder || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.06)')}`,
-                  color: currentTheme.token?.colorText || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.85)'),
-                  padding: 16, 
-                  borderRadius: 6,
-                  fontSize: 12,
-                  overflow: 'auto'
-                }}>
+                        {toolDetailModal.tool.metadata && (
+                            <>
+                                <Divider/>
+                                <Title level={4}>元数据</Title>
+                                <pre style={{
+                                    background: currentTheme.token?.colorFillQuaternary || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.04)' : 'rgba(0, 0, 0, 0.02)'),
+                                    border: `1px solid ${currentTheme.token?.colorBorder || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.06)')}`,
+                                    color: currentTheme.token?.colorText || (themeType === 'nightRain' || themeType === 'plumRain' || themeType === 'deepSeaMoon' || themeType === 'greenMountain' ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.85)'),
+                                    padding: 16,
+                                    borderRadius: 6,
+                                    fontSize: 12,
+                                    overflow: 'auto'
+                                }}>
                   {JSON.stringify(toolDetailModal.tool.metadata, null, 2)}
                 </pre>
-              </>
-            )}
-          </div>
-        )}
-      </Modal>
+                            </>
+                        )}
+                    </div>
+                )}
+            </Modal>
 
-      {/* 工具测试Modal */}
-      <Modal
-        title={
-          <Space>
-            <BugOutlined />
-            测试工具: {testToolModal.tool?.name}
-          </Space>
-        }
-        open={testToolModal.visible}
-        onCancel={() => {
-          setTestToolModal({ visible: false, tool: null, form: null });
-          setTestResult('');
-          form.resetFields();
-        }}
-        onOk={() => {
-          form.validateFields().then(values => {
-            testTool(testToolModal.tool!, values);
-          });
-        }}
-        confirmLoading={loading}
-        width={800}
-      >
-        {testToolModal.tool && (
-          <div>
-            <Alert
-              message="工具测试"
-              description={`正在测试工具 "${testToolModal.tool.name}"，请填写测试参数`}
-              type="info"
-              showIcon
-              style={{ marginBottom: 16 }}
+            {/* 工具测试Modal */}
+            <Modal
+                title={
+                    <Space>
+                        <BugOutlined/>
+                        测试工具: {testToolModal.tool?.name}
+                    </Space>
+                }
+                open={testToolModal.visible}
+                onCancel={() => {
+                    setTestToolModal({visible: false, tool: null, form: null});
+                    setTestResult('');
+                    form.resetFields();
+                }}
+                onOk={() => {
+                    form.validateFields().then(values => {
+                        testTool(testToolModal.tool!, values);
+                    });
+                }}
+                confirmLoading={loading}
+                width={800}
+            >
+                {testToolModal.tool && (
+                    <div>
+                        <Alert
+                            message="工具测试"
+                            description={`正在测试工具 "${testToolModal.tool.name}"，请填写测试参数`}
+                            type="info"
+                            showIcon
+                            style={{marginBottom: 16}}
+                        />
+
+                        <Form form={form} layout="vertical">
+                            {testToolModal.tool.schema?.properties && Object.entries(testToolModal.tool.schema.properties).map(([key, prop]: [string, any]) => (
+                                <Form.Item
+                                    key={key}
+                                    label={key}
+                                    name={key}
+                                    help={prop.description}
+                                >
+                                    {prop.type === 'boolean' ? (
+                                        <Select placeholder={`选择 ${key}`}>
+                                            <Option value={true}>true</Option>
+                                            <Option value={false}>false</Option>
+                                        </Select>
+                                    ) : prop.enum ? (
+                                        <Select placeholder={`选择 ${key}`}>
+                                            {prop.enum.map((option: string) => (
+                                                <Option key={option} value={option}>{option}</Option>
+                                            ))}
+                                        </Select>
+                                    ) : (
+                                        <Input placeholder={`输入 ${key}`}/>
+                                    )}
+                                </Form.Item>
+                            ))}
+                        </Form>
+
+                        {testResult && (
+                            <>
+                                <Divider/>
+                                <Title level={4}>测试结果</Title>
+                                <TextArea
+                                    value={testResult}
+                                    rows={8}
+                                    readOnly
+                                    style={{fontFamily: 'monospace', fontSize: 12}}
+                                />
+                            </>
+                        )}
+                    </div>
+                )}
+            </Modal>
+
+            {/* 文件工具配置Modal */}
+            <FileToolsConfigModal
+                visible={fileToolsConfigModal}
+                onCancel={() => setFileToolsConfigModal(false)}
             />
 
-            <Form form={form} layout="vertical">
-              {testToolModal.tool.schema?.properties && Object.entries(testToolModal.tool.schema.properties).map(([key, prop]: [string, any]) => (
-                <Form.Item
-                  key={key}
-                  label={key}
-                  name={key}
-                  help={prop.description}
-                >
-                  {prop.type === 'boolean' ? (
-                    <Select placeholder={`选择 ${key}`}>
-                      <Option value={true}>true</Option>
-                      <Option value={false}>false</Option>
-                    </Select>
-                  ) : prop.enum ? (
-                    <Select placeholder={`选择 ${key}`}>
-                      {prop.enum.map((option: string) => (
-                        <Option key={option} value={option}>{option}</Option>
-                      ))}
-                    </Select>
-                  ) : (
-                    <Input placeholder={`输入 ${key}`} />
-                  )}
-                </Form.Item>
-              ))}
-            </Form>
+            {/* 时间工具配置Modal */}
+            <TimeToolsConfigModal
+                visible={timeToolsConfigModal}
+                onCancel={() => setTimeToolsConfigModal(false)}
+            />
 
-            {testResult && (
-              <>
-                <Divider />
-                <Title level={4}>测试结果</Title>
-                <TextArea
-                  value={testResult}
-                  rows={8}
-                  readOnly
-                  style={{ fontFamily: 'monospace', fontSize: 12 }}
-                />
-              </>
-            )}
-          </div>
-        )}
-      </Modal>
-
-      {/* 文件工具配置Modal */}
-      <FileToolsConfigModal
-        visible={fileToolsConfigModal}
-        onCancel={() => setFileToolsConfigModal(false)}
-      />
-
-      {/* 时间工具配置Modal */}
-      <TimeToolsConfigModal
-        visible={timeToolsConfigModal}
-        onCancel={() => setTimeToolsConfigModal(false)}
-      />
-
-      {/* 缓存工具配置Modal */}
-      <CacheToolsConfigModal
-        visible={cacheToolsConfigModal}
-        onCancel={() => setCacheToolsConfigModal(false)}
-        onSuccess={() => {
-          loadData(); // 重新加载数据
-        }}
-      />
-    </div>
-  );
+            {/* 缓存工具配置Modal */}
+            <CacheToolsConfigModal
+                visible={cacheToolsConfigModal}
+                onCancel={() => setCacheToolsConfigModal(false)}
+                onSuccess={() => {
+                    loadData(); // 重新加载数据
+                }}
+            />
+        </div>
+    );
 };
 
 export default MCPToolsManagement;


### PR DESCRIPTION
## Summary
• 从缓存工具配置界面移除所有Redis相关选项
• 更新工具类别描述，移除"Redis风格"说明
• 保留对TinyDB、DiskCache、Memcached、LMDB的支持

## Changes Made
- **CacheToolsConfigModal.tsx**: 移除Redis配置字段、表单和处理逻辑
- **MCPToolsManagement.tsx**: 将缓存工具描述从"Redis风格的缓存操作相关工具"改为"缓存操作相关工具"

## Test Plan
- [x] 前端编译无错误
- [x] 后端服务正常启动
- [x] 缓存工具界面正常显示可用后端选项
- [x] 系统运行无Redis相关错误

🤖 Generated with [Claude Code](https://claude.ai/code)