### PR TITLE
feat(mcp): 使用name字段作为MCP工具ID而非UUID

### DIFF
--- a/app/core/mcp_tools_service.py
+++ b/app/core/mcp_tools_service.py
@@ -20,10 +20,10 @@ logger = setup_logging("INFO")
 class MCPTool:
     """MCP工具数据模型"""
     
-    def __init__(self, name: str, description: str, category: str, 
-                 schema: Dict[str, Any], enabled: bool = True, 
+    def __init__(self, name: str, description: str, category: str,
+                 schema: Dict[str, Any], enabled: bool = True,
                  implementation_type: str = "builtin", **kwargs):
-        self.id = kwargs.get('id', str(uuid.uuid4()))
+        self.id = kwargs.get('id', name)  # 使用name作为id而非UUID
         self.name = name
         self.description = description
         self.category = category


### PR DESCRIPTION
## Summary
- 修改MCPTool类构造函数，使用name作为id默认值而非UUID
- 提高工具ID的可读性和可识别性
- 保持ID与工具名称的一致性
- 已通过脚本更新数据库中所有201个工具的ID字段

## Changes Made
- 修改 `app/core/mcp_tools_service.py` 中MCPTool类的构造函数
- 将 `self.id = kwargs.get('id', str(uuid.uuid4()))` 改为 `self.id = kwargs.get('id', name)`
- 使用自动化脚本更新了数据库中201个现有工具记录的ID字段

## Benefits
✅ 工具ID更具可读性（如：`time_get_ts` 而非 `0954d070-1366-4cef-94fb-31966b3c3ab6`）
✅ 便于调试和管理
✅ ID与工具名称保持一致，避免混淆
✅ 符合直观的命名规范

## Test plan
- [x] 验证所有201个工具的ID已更新为name字段值
- [x] 确认新创建的工具使用name作为ID
- [x] 检查现有功能不受影响

🤖 Generated with [Claude Code](https://claude.ai/code)