### PR TITLE
feat: 前端API地址动态配置 - 支持多环境部署

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,6 +1,26 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:8000/api';
+// 动态获取后端地址，使用当前访问地址
+const getAPIBaseURL = () => {
+  // 如果是开发环境且在 localhost，使用默认端口
+  if (process.env.NODE_ENV === 'development' && window.location.hostname === 'localhost') {
+    return 'http://localhost:8000/api';
+  }
+
+  // 生产环境或其他情况，使用当前访问地址的同一域名端口
+  const protocol = window.location.protocol;
+  const hostname = window.location.hostname;
+  const port = window.location.port || (protocol === 'https:' ? '443' : '80');
+
+  // 如果是标准端口，不显示端口号
+  const portSuffix = (protocol === 'https:' && port === '443') || (protocol === 'http:' && port === '80')
+    ? ''
+    : `:${port}`;
+
+  return `${protocol}//${hostname}${portSuffix}/api`;
+};
+
+const API_BASE_URL = getAPIBaseURL();
 
 const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- 修改前端API配置，支持根据访问地址动态获取后端服务地址
- 开发环境保持使用 localhost:8000，生产环境自动使用当前域名和端口
- 解决了前端部署到不同服务器时需要手动修改后端地址的问题

## Changes
- 替换硬编码的 `http://localhost:8000/api` 为动态配置函数
- 开发环境(localhost)：继续使用 `http://localhost:8000/api`  
- 生产环境：自动构建 `${protocol}//${hostname}${port}/api`
- 智能处理标准端口(80/443)的显示优化

## Test plan
- [x] 前端构建测试通过
- [x] API相关单元测试全部通过(24/24)
- [x] 验证开发环境配置逻辑正确
- [x] 验证生产环境配置逻辑正确
- [x] 验证自定义端口处理正确

## Benefits
- 支持一键部署到任意服务器，无需修改配置
- 开发环境体验不受影响
- 代码更加灵活和可维护

🤖 Generated with [Claude Code](https://claude.ai/code)