### PR TITLE
chore(ci): 移除 GitHub Actions 所有缓存策略

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,6 +44,7 @@ jobs:
               - 'Dockerfile'
               - 'docker-compose*.yml'
               - '.dockerignore'
+              - '.github/workflows/docker-build.yml'
             resources:
               - 'resources/**'
 
@@ -150,5 +151,5 @@ jobs:
           echo "**检查的路径:**" >> $GITHUB_STEP_SUMMARY
           echo "- Frontend: \`frontend/**\`" >> $GITHUB_STEP_SUMMARY
           echo "- Backend: \`app/**\`, \`pyproject.toml\`, \`uv.lock\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Docker: \`Dockerfile\`, \`docker-compose*.yml\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker: \`Dockerfile\`, \`docker-compose*.yml\`, \`.github/workflows/docker-build.yml\`" >> $GITHUB_STEP_SUMMARY
           echo "- Resources: \`resources/**\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -74,70 +74,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js and pnpm for frontend cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.0
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Cache frontend build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            frontend/.next/cache
-          key: ${{ runner.os }}-frontend-build-${{ hashFiles('frontend/package*.json', 'frontend/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-frontend-build-
-
-      - name: Setup Python for backend cache
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Cache Python dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/uv
-            .venv
-          key: ${{ runner.os }}-python-${{ hashFiles('pyproject.toml', 'uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-python-
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Cache Docker build context
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.docker/buildx
-            /var/lib/docker/buildx
-          key: ${{ runner.os }}-docker-buildx-${{ hashFiles('Dockerfile', 'frontend/package*.json', 'pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-docker-buildx-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -170,24 +106,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha
-            type=local,src=/tmp/.buildx-cache
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
-          cache-to: |
-            type=gha,mode=max
-            type=local,dest=/tmp/.buildx-cache-new,mode=max
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-            BUILDKIT_CACHE_MOUNT=true
           provenance: false
           sbom: false
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
 
       - name: Generate build summary
         run: |
@@ -209,19 +129,11 @@ jobs:
           echo "- Docker: ${{ needs.detect-changes.outputs.docker-changed }}" >> $GITHUB_STEP_SUMMARY
           echo "- Resources: ${{ needs.detect-changes.outputs.resources-changed }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "⚡ **Performance optimizations applied:**" >> $GITHUB_STEP_SUMMARY
+          echo "⚡ **Build optimizations:**" >> $GITHUB_STEP_SUMMARY
           echo "- Smart change detection" >> $GITHUB_STEP_SUMMARY
-          echo "- Multi-layer Docker caching strategy" >> $GITHUB_STEP_SUMMARY
-          echo "  - GitHub Actions cache (GHA)" >> $GITHUB_STEP_SUMMARY
-          echo "  - Local BuildX cache (/tmp/.buildx-cache)" >> $GITHUB_STEP_SUMMARY
-          echo "  - Registry cache (ghcr.io)" >> $GITHUB_STEP_SUMMARY
-          echo "- Frontend dependency caching (pnpm store + build cache)" >> $GITHUB_STEP_SUMMARY
-          echo "- Backend dependency caching (Python + uv)" >> $GITHUB_STEP_SUMMARY
-          echo "- Docker BuildX context caching" >> $GITHUB_STEP_SUMMARY
-          echo "- BuildKit inline cache + mount cache" >> $GITHUB_STEP_SUMMARY
-          echo "- pnpm for faster package management" >> $GITHUB_STEP_SUMMARY
-          echo "- Optimized Docker Buildx configuration" >> $GITHUB_STEP_SUMMARY
+          echo "- Single platform build (linux/amd64)" >> $GITHUB_STEP_SUMMARY
           echo "- Disabled SBOM/Provenance for speed" >> $GITHUB_STEP_SUMMARY
+          echo "- No caching for clean builds" >> $GITHUB_STEP_SUMMARY
 
   # 仅在文档或非构建文件变更时运行的快速作业
   skip-notification:


### PR DESCRIPTION
## 变更内容

🗑️ **移除所有 GitHub Actions 缓存机制**

### 移除的缓存类型
- **前端缓存**
  - pnpm store 缓存
  - 前端构建缓存 (.next/cache)
- **后端缓存**  
  - Python 依赖缓存 (~/.cache/uv)
  - 虚拟环境缓存 (.venv)
- **Docker 缓存**
  - Docker 层缓存 (/tmp/.buildx-cache)
  - BuildX 上下文缓存
  - GitHub Actions 缓存 (type=gha)
  - 注册表缓存 (type=registry)
  - BuildKit inline cache 和 mount cache

### 优化效果
- ✅ **简化构建流程** - 移除复杂的缓存依赖链
- ✅ **提高构建一致性** - 每次都是干净的构建环境
- ✅ **减少构建失败率** - 避免缓存相关的构建问题
- ✅ **降低维护成本** - 无需管理复杂的缓存策略

### 构建时间影响
虽然移除缓存会增加构建时间，但获得了：
- 更可靠的构建结果
- 更简单的故障排查
- 更一致的部署环境

### 文件变更
- `.github/workflows/docker-build.yml`: 移除所有缓存相关配置 (-88 行)
- 更新构建摘要，反映零缓存架构

## 测试计划
- [x] 验证工作流语法正确性
- [ ] 测试 master 分支推送触发构建
- [ ] 验证 Docker 镜像正常构建和推送

🤖 Generated with [Claude Code](https://claude.ai/code)